### PR TITLE
Sign up, sign in, sign out 구현, api 요청 부분 리팩토링

### DIFF
--- a/src/components/Issues/detail/Header/DetailHeader.tsx
+++ b/src/components/Issues/detail/Header/DetailHeader.tsx
@@ -130,21 +130,20 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const DetailHeader = props => {
+const DetailHeader = ({ issue, fileInfo, date }) => {
   const classes = useStyles();
   const history = useHistory();
-
   const handleResolve = () => {
     const updateIssuesResolve = async () => {
       const result = await axios.put(
         `${process.env.API_URL}/issue/resolved`,
-        { issueIdList: props.issueId, resolved: true },
+        { issueIdList: issue._id, resolved: true },
         {
           withCredentials: true,
         }
       );
 
-      history.push(`/projects/${props.projectId}`);
+      history.push(`/projects/${issue.projectId._id}`);
     };
 
     updateIssuesResolve();
@@ -154,14 +153,14 @@ const DetailHeader = props => {
       <div className={classes.IssueContainer}>
         <div className={classes.IssueContainerLeft}>
           <div className={classes.IssueInfoContainer}>
-            <strong className={classes.IssueName}>{props.name}</strong>{' '}
-            <p className={classes.FileInfo}>{props.fileInfo}</p>
+            <strong className={classes.IssueName}>{issue.name}</strong>{' '}
+            <p className={classes.FileInfo}>{fileInfo}</p>
           </div>
           <div className={classes.messageContainer}>
             <FiberManualRecordIcon className={classes.messageIcon} />{' '}
-            <h2 className={classes.messageValue}>{props.message}</h2>
+            <h2 className={classes.messageValue}>{issue.message}</h2>
           </div>
-          <h3 className={classes.eventDate}> {props.date}</h3>
+          <h3 className={classes.eventDate}> {date}</h3>
           <div className={classes.ButtonContainer}>
             <Button
               variant="contained"
@@ -194,16 +193,18 @@ const DetailHeader = props => {
             <div className={classes.utilsName}>Assigned</div>
           </div>
           <div className={classes.utilsNameContainer}>
-            <p className={classes.utilsProjectValue}>icon _ project name</p>
+            <p className={classes.utilsProjectValue}>{issue.projectId.title}</p>
             <div className={classes.utilsValueDiv}>
-              <div className={classes.utilsNameValue}>{props.count}</div>
+              <div className={classes.utilsNameValue}>
+                {issue.errorEvents.length}
+              </div>
             </div>
 
             <div className={classes.utilsValueDiv}>
               <Assigned
-                members={props.members}
-                issueId={props.issueId}
-                assignee={props.assignee}
+                members={issue.projectId.members}
+                issueId={issue._id}
+                assignee={issue.assignee}
               />
             </div>
           </div>

--- a/src/components/Issues/detail/MainContainer.tsx
+++ b/src/components/Issues/detail/MainContainer.tsx
@@ -67,7 +67,7 @@ const MainContainer = (props: { issueId: string }) => {
 
   useEffect(() => {}, [currentErrorEventIdx]);
 
-  const initISsueData = async () => {
+  const initIssueData = async () => {
     setIsLoading(true);
     const issueData = await IssueDetailApi.getDetailIssueByIssueId(issueId);
     setIssue(issueData);
@@ -82,7 +82,7 @@ const MainContainer = (props: { issueId: string }) => {
   };
 
   useEffect(() => {
-    initISsueData(); // 이슈 정보, 가장 최근 발생한 에러 이벤트 받아옴
+    initIssueData(); // 이슈 정보, 가장 최근 발생한 에러 이벤트 받아옴
   }, []);
 
   if (isLoading) {
@@ -103,14 +103,8 @@ const MainContainer = (props: { issueId: string }) => {
     <div className={classes.DetailContainer}>
       <div>
         <DetailHeader
-          name={issue.name}
+          issue={issue}
           fileInfo={fileInfo}
-          message={issue.message}
-          count={issue.errorEvents.length}
-          issueId={issue._id}
-          projectId={issue.projectId._id}
-          members={issue.projectId.members}
-          assignee={issue.assignee}
           date={new Date(errorEvent.date).toLocaleString()}
         />
       </div>

--- a/src/components/Issues/issue/Assigned.tsx
+++ b/src/components/Issues/issue/Assigned.tsx
@@ -83,9 +83,14 @@ const ModalBody = React.forwardRef((props: any, ref: any) => (
   </div>
 ));
 
-export default function Assigned(props) {
+const Assigned = props => {
   const classes = useStyles();
   const [modalOpen, setModalOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+  const projectMembers = props.members;
+
   const handleModalOpen = () => {
     setModalOpen(true);
   };
@@ -93,8 +98,6 @@ export default function Assigned(props) {
   const handleModalClose = () => {
     setModalOpen(false);
   };
-
-  const [anchorEl, setAnchorEl] = useState(null);
 
   const handleClick = event => {
     setAnchorEl(event.currentTarget);
@@ -104,43 +107,6 @@ export default function Assigned(props) {
     setAnchorEl(null);
   };
 
-  const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
-
-  const [projectMembers, setProjectMembers] = useState(props.members);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const getProject = async () => {
-      try {
-        setProjectMembers(null);
-        setLoading(true);
-
-        const response: any = await axios.get(
-          `${process.env.API_URL}/project/v2/${props.projectId}`,
-          {
-            withCredentials: true,
-          }
-        );
-
-        setProjectMembers(response.data.members);
-        setLoading(false);
-      } catch (e) {
-        setError(e);
-      }
-    };
-
-    if (props.projectId) {
-      getProject();
-    } else {
-      setLoading(false);
-    }
-  }, []);
-
-  if (error) return <div>에러가 발생했습니다</div>;
-
-  //담당자 변경하는 api 요청을 추가해야함
   const handleAssigned = event => {
     let memberContainer = event.target.closest(`div`);
 
@@ -179,10 +145,7 @@ export default function Assigned(props) {
     changeAssinged(props.issueId, selectedMember._id, props.projectId);
   };
 
-  if (loading) {
-    return <div>로딩 중...</div>;
-  }
-  let Members =
+  const Members =
     projectMembers.length > 0 ? (
       <div className={classes.usersContainer}>
         {projectMembers.map(member => (
@@ -253,22 +216,6 @@ export default function Assigned(props) {
 
   return (
     <div className="assignedContainer">
-      {/* <Button
-        className={classes.openUserListButton}
-        aria-describedby={id}
-        id={props.issueId + 'assigneeButton'}
-        variant="contained"
-        onClick={handleClick}
-      >
-        <PersonAddIcon
-          className={classes.userIcon}
-          id={props.issueId + 'userIcon'}
-        />
-        <ArrowDropDownIcon
-          className={classes.openIcon}
-          id={props.issueId + 'openIcon'}
-        />
-      </Button> */}
       {getAssignee(props.assignee)}
       <Popover
         id={id}
@@ -296,4 +243,6 @@ export default function Assigned(props) {
       </Modal>
     </div>
   );
-}
+};
+
+export default Assigned;

--- a/src/components/Issues/issue/Assigned.tsx
+++ b/src/components/Issues/issue/Assigned.tsx
@@ -74,6 +74,15 @@ const changeAssinged = async (
   );
 };
 
+const ModalBody = React.forwardRef((props: any, ref: any) => (
+  <div ref={ref}>
+    <InviteModal
+      setModalOpen={props.setModalOpen}
+      projectId={props.projectId}
+    />
+  </div>
+));
+
 export default function Assigned(props) {
   const classes = useStyles();
   const [modalOpen, setModalOpen] = useState(false);
@@ -283,7 +292,7 @@ export default function Assigned(props) {
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        <InviteModal setModalOpen={setModalOpen} projectId={props.projectId} />
+        <ModalBody setModalOpen={setModalOpen} projectId={props.projectId} />
       </Modal>
     </div>
   );

--- a/src/components/Issues/issue/IssueItem.tsx
+++ b/src/components/Issues/issue/IssueItem.tsx
@@ -87,56 +87,23 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const IssueItem = props => {
+const IssueItem = ({ issue, onClick }) => {
   const history = useHistory();
   const classes = useStyles();
 
   const now = moment();
-  const issueDate = moment(props.date);
+  const issueDate = moment(issue.updateAt);
   const dateDiff: string =
     now.diff(issueDate, 'days') > 0
       ? `${String(now.diff(issueDate, 'days'))}일`
       : `${String(now.diff(issueDate, 'hour'))}시간`;
-  const dateForm = moment(props.date).format('YYYY.MM.DD HH:MM');
-  const pathInfo = props.stack.split('\n')[1].split('/');
+  const dateForm = moment(issue.updateAt).format('YYYY.MM.DD HH:MM');
+  const pathInfo = issue.stack.split('\n')[1].split('/');
   const fileInfo = pathInfo[pathInfo.length - 1];
 
-  const [errorEvents, setErrorEvents] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-
   function onTitleCiick() {
-    history.push(`/projects/issues/detail/${props.issueId}`);
+    history.push(`/projects/issues/detail/${issue._id}`);
   }
-
-  useEffect(() => {
-    const getIssues = async () => {
-      try {
-        setError(null);
-        setErrorEvents(null);
-
-        setLoading(true);
-        const respone: any = await axios.get(
-          `${process.env.API_URL}/errorevent/issue/${props.issueId}`,
-          {
-            withCredentials: true,
-          }
-        );
-        setErrorEvents(respone.data);
-      } catch (e) {
-        setError(e);
-      }
-      setLoading(false);
-    };
-
-    getIssues();
-  }, []);
-
-  if (loading) {
-    return <div>로딩중</div>;
-  }
-  if (error) return <div>에러가 발생했습니다</div>;
-  if (!errorEvents) return null;
 
   return (
     <div className={classes.container}>
@@ -144,30 +111,33 @@ const IssueItem = props => {
         <div className={classes.IssueNameArea}>
           <input
             type="checkbox"
-            id={props.issueId}
-            onClick={props.onClick}
+            id={issue._id}
+            onClick={onClick}
             className="item_checkbox"
             style={{ alignSelf: 'center' }}
           />
           <div className={classes.IssueName} onClick={onTitleCiick}>
-            {props.name + '' + fileInfo}
+            {issue.name + '' + fileInfo}
           </div>
         </div>
-        <div className={classes.IssueInfoItem}>{props.description}</div>
+        <div className={classes.IssueInfoItem}>{issue.message}</div>
         <div className={classes.timeContainer}>
           <AccessTimeIcon fontSize="small" className={classes.timeIcon} />
           {dateForm}, {dateDiff} 전
         </div>
       </div>
-      <Graph errorEvents={errorEvents} />
+      <Graph errorEvents={issue.errorEvents} />
       <div className={classes.column}>
-        <Avatar className={classes.countAvatar}>{props.eventNum}</Avatar>
+        <Avatar className={classes.countAvatar}>
+          {issue.errorEvents.length}
+        </Avatar>
       </div>
       <div className={classes.column}>
         <Assigned
-          projectId={props.projectId}
-          issueId={props.issueId}
-          assignee={props.assignee}
+          projectId={issue.projectId._id}
+          issueId={issue._id}
+          assignee={issue.assignee}
+          members={issue.projectId.members}
         />
       </div>
     </div>

--- a/src/components/Issues/issue/TableColumn.tsx
+++ b/src/components/Issues/issue/TableColumn.tsx
@@ -145,20 +145,7 @@ const TableColumn = () => {
         <div className={classes.column}>Assigned</div>
       </div>
       {issues.map(issue => (
-        <IssueItem
-          key={issue._id}
-          issueId={issue._id}
-          name={issue.name}
-          description={issue.message}
-          eventNum={issue.errorEvents.length}
-          userNum={issue.users}
-          assignee={issue.assignee}
-          errorEvents={issue.errorEvents}
-          stack={issue.stack}
-          date={issue.updatedAt}
-          projectId={issue.projectId}
-          onClick={handleChecked}
-        />
+        <IssueItem key={issue._id} issue={issue} onClick={handleChecked} />
       ))}
     </div>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import Grid from '@material-ui/core/Grid';
 import Modal from '@material-ui/core/Modal';
@@ -50,6 +50,7 @@ const ModalBody = React.forwardRef((props: any, ref: any) => (
 
 const GlobalHeader = () => {
   const history = useHistory();
+  const location = useLocation();
 
   const [modalOpen, setModalOpen] = useState(false);
   const [isSignIn, setSignIn] = useState<boolean>(false);
@@ -82,7 +83,7 @@ const GlobalHeader = () => {
 
   useEffect(() => {
     setSignIn(!!document.cookie);
-  }, [document.cookie]);
+  }, [document.cookie, location]);
 
   return (
     <>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import Grid from '@material-ui/core/Grid';
 import Modal from '@material-ui/core/Modal';
 import SignInModal from '@components/common/SignInModal';
+import Api from '@utils/Api';
 
 const HeaderButton = styled.button`
   margin: 0 auto;
@@ -51,6 +52,7 @@ const GlobalHeader = () => {
   const history = useHistory();
 
   const [modalOpen, setModalOpen] = useState(false);
+  const [isSignIn, setSignIn] = useState<boolean>(false);
 
   const handleModalOpen = () => {
     setModalOpen(true);
@@ -72,6 +74,16 @@ const GlobalHeader = () => {
     history.push('/tutorial');
   };
 
+  const clickSignOut = async () => {
+    await Api.getSignOut();
+    setSignIn(false);
+    history.push('/');
+  };
+
+  useEffect(() => {
+    setSignIn(!!document.cookie);
+  }, [document.cookie]);
+
   return (
     <>
       <HeaderContainer>
@@ -84,7 +96,11 @@ const GlobalHeader = () => {
             <HeaderButton onClick={tutorialClicked}>Tutorial</HeaderButton>
           </Grid>
           <Grid item xs>
-            <HeaderButton onClick={handleModalOpen}>Sign In</HeaderButton>
+            {isSignIn ? (
+              <HeaderButton onClick={clickSignOut}>Sign Out</HeaderButton>
+            ) : (
+              <HeaderButton onClick={handleModalOpen}>Sign In</HeaderButton>
+            )}
           </Grid>
         </Grid>
       </HeaderContainer>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import Grid from '@material-ui/core/Grid';
+import Modal from '@material-ui/core/Modal';
+import SignInModal from '@components/common/SignInModal';
 
 const HeaderButton = styled.button`
   margin: 0 auto;
@@ -39,8 +41,24 @@ const HeaderContainer = styled.div`
   background-color: rgba(0, 0, 0, 0.3);
 `;
 
+const ModalBody = React.forwardRef((props: any, ref: any) => (
+  <div ref={ref}>
+    <SignInModal setModalOpen={props.setModalOpen} />
+  </div>
+));
+
 const GlobalHeader = () => {
   const history = useHistory();
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleModalOpen = () => {
+    setModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setModalOpen(false);
+  };
 
   const HomeHandler = () => {
     history.push('/');
@@ -55,21 +73,25 @@ const GlobalHeader = () => {
   };
 
   return (
-    <HeaderContainer>
-      <Grid container spacing={1}>
-        <Grid item xs>
-          <HomeButton onClick={HomeHandler}>@Acent</HomeButton>
+    <>
+      <HeaderContainer>
+        <Grid container spacing={1}>
+          <Grid item xs>
+            <HomeButton onClick={HomeHandler}>@Acent</HomeButton>
+          </Grid>
+          <Grid item xs={6}>
+            <HeaderButton onClick={docsClicked}>Docs</HeaderButton>
+            <HeaderButton onClick={tutorialClicked}>Tutorial</HeaderButton>
+          </Grid>
+          <Grid item xs>
+            <HeaderButton onClick={handleModalOpen}>Sign In</HeaderButton>
+          </Grid>
         </Grid>
-        <Grid item xs={6}>
-          <HeaderButton onClick={docsClicked}>Docs</HeaderButton>
-          <HeaderButton onClick={tutorialClicked}>Tutorial</HeaderButton>
-        </Grid>
-        <Grid item xs>
-          <HeaderButton>Sign in</HeaderButton>
-          <HeaderButton>Sign up</HeaderButton>
-        </Grid>
-      </Grid>
-    </HeaderContainer>
+      </HeaderContainer>
+      <Modal open={modalOpen} onClose={handleModalClose}>
+        <ModalBody setModalOpen={setModalOpen} />
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/common/LeftBar.tsx
+++ b/src/components/common/LeftBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
@@ -8,7 +8,6 @@ import Divider from '@material-ui/core/Divider';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import Badge from '@material-ui/core/Badge';
 
 import FolderSharedIcon from '@material-ui/icons/FolderShared';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
@@ -81,19 +80,24 @@ const LeftBar = () => {
     if (target) {
       switch (target.title) {
         case 'Projects':
-          if (content[0] !== 'Projects') history.push('/projects');
+          if (content[0] !== 'Projects') {
+            history.push('/projects');
+          }
           break;
         case 'Issues':
-          if (content[0] !== 'Issues' && content[1] !== 'none' && content[1])
+          if (content[0] !== 'Issues' && content[1]) {
             history.push(`/projects/issues/${content[1]}`);
+          }
           break;
         case 'Alerts':
-          if (content[0] !== 'Alerts' && content[1] !== 'none')
+          if (content[0] !== 'Alerts') {
             history.push(`/alerts`);
+          }
           break;
         case 'Stats':
-          if (content[0] !== 'Stats' && content[1] !== 'none' && content[1])
+          if (content[0] !== 'Stats' && content[1]) {
             history.push(`/projects/${content[1]}/stats`);
+          }
           break;
         default:
           break;

--- a/src/components/common/SignInModal.tsx
+++ b/src/components/common/SignInModal.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import { makeStyles } from '@material-ui/core/styles';
+import Api from '@utils/Api';
+
+const getModalStyle = () => {
+  const top = 50;
+  const left = 50;
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  };
+};
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    position: 'absolute',
+    width: 400,
+    borderRadius: '5px',
+    backgroundColor: 'rgba(241, 241, 241, 1)',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+}));
+
+const SignInForm = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const SignInInputTitle = styled.p`
+  padding-top: 1rem;
+`;
+
+const SignInInput = styled.input`
+  height: 2rem;
+  margin-top: 1%;
+  background-color: rgba(0, 0, 0, 0.5);
+  outline: none;
+  border: none;
+  padding: 10px;
+  color: rgba(241, 241, 241, 1);
+  font-size: 1rem;
+  border-radius: 5px;
+`;
+
+const SignInButton = styled.button`
+  margin-top: 2rem;
+  padding: 1rem;
+  background-color: #00bfa5;
+  color: #f1f1f1;
+  border-radius: 5px;
+  font-size: 2rem;
+  :not([disabled]):hover {
+    background-color: rgba(0, 191, 165, 0.5);
+    color: gray;
+    transition: 0.5s;
+  }
+  :disabled:hover {
+    cursor: auto;
+  }
+`;
+
+const Divider = styled.div`
+  width: inherit;
+  margin: 2rem 0 0 0;
+  border: 0.1rem solid rgba(0, 0, 0, 1);
+`;
+
+const SignInModal = ({ setModalOpen }) => {
+  const history = useHistory();
+
+  const classes = useStyles();
+  const [modalStyle] = useState(getModalStyle);
+
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [disabled, setDisabled] = useState<boolean>(true);
+
+  const changeInput = setInput => event => {
+    setInput(event.target.value);
+  };
+
+  const clickSignIn = async () => {
+    const userData = { email, pwd: password };
+    const {
+      data: { signIn, causeEmail },
+    } = await Api.postSignIn(userData);
+
+    if (signIn) {
+      setModalOpen(false);
+      history.push('/projects');
+    }
+  };
+
+  const clickGoogle = () => {
+    window.location.href = `${process.env.API_URL}/oauth/google`;
+  };
+
+  const clickGitHub = () => {
+    window.location.href = `${process.env.API_URL}/oauth/github`;
+  };
+
+  useEffect(() => {
+    setDisabled(!(email && password));
+  }, [email, password]);
+
+  return (
+    <div style={modalStyle} className={classes.paper}>
+      <SignInForm>
+        <SignInInputTitle>Email</SignInInputTitle>
+        <SignInInput value={email} onChange={changeInput(setEmail)} />
+        <SignInInputTitle>Password</SignInInputTitle>
+        <SignInInput
+          type="password"
+          value={password}
+          onChange={changeInput(setPassword)}
+        />
+        <SignInButton disabled={disabled} onClick={clickSignIn}>
+          Sign In
+        </SignInButton>
+        <Divider />
+        <SignInButton onClick={clickGoogle}>Sign In with Google</SignInButton>
+        <SignInButton onClick={clickGitHub}>Sign In with GitHub</SignInButton>
+      </SignInForm>
+    </div>
+  );
+};
+
+export default SignInModal;

--- a/src/components/common/SignInModal.tsx
+++ b/src/components/common/SignInModal.tsx
@@ -93,6 +93,12 @@ const SignInModal = ({ setModalOpen }) => {
     if (signIn) {
       setModalOpen(false);
       history.push('/projects');
+    } else {
+      const comment = causeEmail
+        ? 'Email is incorrect'
+        : 'Password is incorrect';
+      setEmail(comment);
+      setPassword('');
     }
   };
 

--- a/src/components/login/RightContents.tsx
+++ b/src/components/login/RightContents.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
 import Api from '@utils/Api';
 
@@ -58,6 +59,7 @@ const TextField = styled.input<{ borderOption: string }>`
   outline: none;
   border: none;
   padding: 10px;
+  color: rgba(241, 241, 241, 1);
   font-size: 1rem;
   border: ${props => props.borderOption};
   border-radius: 5px;
@@ -94,6 +96,8 @@ const OauthLink = styled.i`
 `;
 
 const RightContents = () => {
+  const history = useHistory();
+
   const OauthHandler = () => {
     window.location.href = `${process.env.API_URL}/oauth/google`;
   };
@@ -134,8 +138,9 @@ const RightContents = () => {
   const clickSignUp = async () => {
     const data = { name: usernameInput, pwd: passwordInput, email: emailInput };
     const {
-      data: { isCreated },
+      data: { signUp },
     } = await Api.postSignUp(data);
+    if (signUp) history.push('/projects');
   };
 
   useEffect(() => {

--- a/src/components/login/RightContents.tsx
+++ b/src/components/login/RightContents.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import styled, { css, keyframes } from 'styled-components';
-import { makeStyles } from '@material-ui/core/styles';
+import React, { useEffect, useState } from 'react';
+import styled, { keyframes } from 'styled-components';
+import Api from '@utils/Api';
 
 const MIN_USERNAME_LENGTH = 4;
 const MIN_PASSWORD_LENGTH = 8;
@@ -75,10 +75,13 @@ const SingUpButton = styled.button`
   border-radius: 5px;
   font-size: 2rem;
   color: gray;
-  :hover {
+  :not([disabled]):hover {
     background-color: #00bfa5;
     color: #f1f1f1;
     transition: 0.5s;
+  }
+  :disabled:hover {
+    cursor: auto;
   }
 `;
 
@@ -101,6 +104,7 @@ const RightContents = () => {
   const [usernameInput, setUsenameInput] = useState<string>('');
   const [emailInput, setEmailInput] = useState<string>('');
   const [passwordInput, setPasInput] = useState<string>('');
+  const [disabled, setDisabled] = useState<boolean>(true);
 
   const handleInput = setInput => event => {
     setInput(event.target.value);
@@ -127,6 +131,17 @@ const RightContents = () => {
     return '2px solid rgba(0, 255, 0, 0.5)';
   };
 
+  const clickSignUp = async () => {
+    const data = { name: usernameInput, pwd: passwordInput, email: emailInput };
+    const {
+      data: { isCreated },
+    } = await Api.postSignUp(data);
+  };
+
+  useEffect(() => {
+    setDisabled(!(usernameInput && emailInput && passwordInput));
+  }, [usernameInput, emailInput, passwordInput]);
+
   return (
     <Container>
       <BackgroundImage src="../../public/svg/circle.svg" />
@@ -152,8 +167,11 @@ const RightContents = () => {
           value={passwordInput}
           onChange={handleInput(setPasInput)}
           borderOption={checkInputValidation(passwordInput, isRightPassword)}
+          type="password"
         />
-        <SingUpButton>Sign Up</SingUpButton>
+        <SingUpButton disabled={disabled} onClick={clickSignUp}>
+          Sign Up
+        </SingUpButton>
         <FormText>
           Click this if you want to sign in more simply. You are signed in with{' '}
           <OauthLink onClick={OauthHandler}>Google</OauthLink> or

--- a/src/components/login/RightContents.tsx
+++ b/src/components/login/RightContents.tsx
@@ -105,9 +105,9 @@ const RightContents = () => {
     window.location.href = `${process.env.API_URL}/oauth/github`;
   };
 
-  const [usernameInput, setUsenameInput] = useState<string>('');
+  const [usernameInput, setUsernameInput] = useState<string>('');
   const [emailInput, setEmailInput] = useState<string>('');
-  const [passwordInput, setPasInput] = useState<string>('');
+  const [passwordInput, setPasswordInput] = useState<string>('');
   const [disabled, setDisabled] = useState<boolean>(true);
 
   const handleInput = setInput => event => {
@@ -141,6 +141,9 @@ const RightContents = () => {
       data: { signUp },
     } = await Api.postSignUp(data);
     if (signUp) history.push('/projects');
+    setEmailInput('Email already signed up');
+    setUsernameInput('');
+    setPasswordInput('');
   };
 
   useEffect(() => {
@@ -158,7 +161,7 @@ const RightContents = () => {
         <FormText>Username</FormText>
         <TextField
           value={usernameInput}
-          onChange={handleInput(setUsenameInput)}
+          onChange={handleInput(setUsernameInput)}
           borderOption={checkInputValidation(usernameInput, isRightUserName)}
         />
         <FormText>Email</FormText>
@@ -170,7 +173,7 @@ const RightContents = () => {
         <FormText>Password</FormText>
         <TextField
           value={passwordInput}
-          onChange={handleInput(setPasInput)}
+          onChange={handleInput(setPasswordInput)}
           borderOption={checkInputValidation(passwordInput, isRightPassword)}
           type="password"
         />

--- a/src/context/IssuesProvider.tsx
+++ b/src/context/IssuesProvider.tsx
@@ -21,7 +21,7 @@ const reducer = (state, action) => {
 export const IssuesStateContext = createContext([]);
 export const IssuesDispatchContext = createContext(null);
 
-const ResolveProvider = ({ children }) => {
+const IssuesProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, []);
   const positionDispatch = useContext(PositionDispatchContext);
   const userState = useContext(UserStateContext);
@@ -65,4 +65,4 @@ const ResolveProvider = ({ children }) => {
   );
 };
 
-export default ResolveProvider;
+export default IssuesProvider;

--- a/src/context/IssuesProvider.tsx
+++ b/src/context/IssuesProvider.tsx
@@ -31,14 +31,8 @@ const IssuesProvider = ({ children }) => {
       if (userState.length > 0) {
         if (userState[0]) {
           positionDispatch({
-            type: 'set',
-            content: 'Issues',
+            type: 'setProjectId',
             projectId: userState[0],
-          });
-        } else {
-          positionDispatch({
-            type: 'set',
-            content: 'Projects',
           });
         }
 

--- a/src/context/PositionProvider.tsx
+++ b/src/context/PositionProvider.tsx
@@ -1,18 +1,13 @@
-import React, { useState, useEffect, createContext, useReducer } from 'react';
+import React, { createContext, useReducer } from 'react';
 
 const reducer = (state, action) => {
   switch (action.type) {
     case 'set':
       return [action.content, action.projectId];
-    case 'update':
-      const data = [action.content, action.projectId];
-      return data;
     case 'setPosition':
-      const newPosition = [action.content, state[1]];
-      return newPosition;
-    case 'setUser':
-      const newData = [state[0], action.projectId];
-      return newData;
+      return [action.content, state[1]];
+    case 'setProjectId':
+      return [state[0], action.projectId];
     default:
       break;
   }

--- a/src/context/UserProvider.tsx
+++ b/src/context/UserProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useReducer, useEffect, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import Api from '@utils/Api';
 
 const reducer = (state, action) => {
@@ -18,6 +19,8 @@ export const UserStateContext = createContext([]);
 export const UserDispatchContext = createContext(null);
 
 const UserProvider = ({ children }) => {
+  const location = useLocation();
+
   const [state, dispatch] = useReducer(reducer, []);
 
   useEffect(() => {
@@ -33,7 +36,7 @@ const UserProvider = ({ children }) => {
     };
 
     getData();
-  }, []);
+  }, [location]);
 
   return (
     <UserStateContext.Provider value={state}>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -79,7 +79,6 @@ const Projects = () => {
   const positionDispatch = React.useContext(PositionDispatchContext);
 
   const [projects, setProjects] = useState([]);
-  const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const readProjects = async () => {
@@ -89,20 +88,12 @@ const Projects = () => {
     setProjects([...data]);
   };
 
-  const readUserInfo = async () => {
-    setLoading(true);
-    const { data } = await Api.getUser();
-    setLoading(false);
-    setUser(data);
-  };
-
   const clickProjectsHeaderButton = () => {
     history.push('/projects/new');
   };
 
   useEffect(() => {
     readProjects();
-    readUserInfo();
     positionDispatch({
       type: 'setPosition',
       content: 'Projects',

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -124,6 +124,16 @@ const postSignIn = async (data: SignInUser): Promise<any> => {
   }
 };
 
+const getSignOut = async (): Promise<any> => {
+  try {
+    return await axios.get(`${process.env.API_URL}/signOut`, {
+      withCredentials: true,
+    });
+  } catch (err) {
+    return err;
+  }
+};
+
 export default {
   getUser,
   getProject,
@@ -136,4 +146,5 @@ export default {
   postInvite,
   postSignUp,
   postSignIn,
+  getSignOut,
 };

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -1,5 +1,10 @@
 import axios from 'axios';
-import { CreateProject, InviteMember, SignUpUser } from './Interface';
+import {
+  CreateProject,
+  InviteMember,
+  SignUpUser,
+  SignInUser,
+} from './Interface';
 
 const getUser = async () => {
   try {
@@ -109,6 +114,16 @@ const postSignUp = async (data: SignUpUser): Promise<any> => {
   }
 };
 
+const postSignIn = async (data: SignInUser): Promise<any> => {
+  try {
+    return await axios.post(`${process.env.API_URL}/signIn`, data, {
+      withCredentials: true,
+    });
+  } catch (err) {
+    return err;
+  }
+};
+
 export default {
   getUser,
   getProject,
@@ -120,4 +135,5 @@ export default {
   getUserByEamil,
   postInvite,
   postSignUp,
+  postSignIn,
 };

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { CreateProject } from './Interface';
+import { CreateProject, InviteMember, SignUpUser } from './Interface';
 
 const getUser = async () => {
   try {
@@ -84,13 +84,26 @@ const getUserByEamil = async (email: string): Promise<any> => {
   }
 };
 
-const postInvite = async (projectId: string, data: any): Promise<any> => {
+const postInvite = async (
+  projectId: string,
+  data: InviteMember
+): Promise<any> => {
   try {
     return await axios.post(
       `${process.env.API_URL}/project/${projectId}/invite`,
       data,
       { withCredentials: true }
     );
+  } catch (err) {
+    return err;
+  }
+};
+
+const postSignUp = async (data: SignUpUser): Promise<any> => {
+  try {
+    return await axios.post(`${process.env.API_URL}/signUp`, data, {
+      withCredentials: true,
+    });
   } catch (err) {
     return err;
   }
@@ -106,4 +119,5 @@ export default {
   getChartTag,
   getUserByEamil,
   postInvite,
+  postSignUp,
 };

--- a/src/utils/Interface.ts
+++ b/src/utils/Interface.ts
@@ -7,3 +7,9 @@ export interface CreateProject {
 export interface InviteMember {
   userId: string;
 }
+
+export interface SignUpUser {
+  name: string;
+  email: string;
+  pwd: string;
+}

--- a/src/utils/Interface.ts
+++ b/src/utils/Interface.ts
@@ -13,3 +13,8 @@ export interface SignUpUser {
   email: string;
   pwd: string;
 }
+
+export interface SignInUser {
+  email: string;
+  pwd: string;
+}


### PR DESCRIPTION
**요약**

Local sign up, sign in modal, sign out 기능을 구현했습니다.

**내용**

- 메인 페이지에서 회원가입이 가능하도록 했습니다. 
- 회원가입시 이메일 중복 여부를 확인합니다. 
- 로컬 로그인 기능을 구현했습니다. 
- 헤더에 `Sign In` 버튼을 유저의 로그인 여부에 따라서 `Sign Out` 버튼으로 바뀌게 했습니다.  